### PR TITLE
Fix date & number format

### DIFF
--- a/Doppler.Currency.Test/BnaHandlerTests.cs
+++ b/Doppler.Currency.Test/BnaHandlerTests.cs
@@ -41,7 +41,7 @@ namespace Doppler.Currency.Test
         }
 
         [Fact]
-        public async Task GetCurrency_ShouldBeReturnUsdCurrencyOfBna_WhenHtmlHaveTwoCurrencyToReturnOk()
+        public async Task GetCurrency_ShouldBeReturnCurrencyOk_WhenHtmlHaveTwoCurrency()
         {
             var dateTime = new DateTime(2020, 02, 05);
 
@@ -93,11 +93,11 @@ namespace Doppler.Currency.Test
 
             var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Ars);
 
-            Assert.Equal(dateTime.ToUniversalTime(), result.Entity.Date);
+            Assert.Equal("2020-02-05", result.Entity.Date);
         }
 
         [Fact]
-        public async Task GetCurrency_ShouldBeReturnCurrencyOfBna_WhenHtmlHaveOneCurrencyToReturnOk()
+        public async Task GetCurrency_ShouldBeReturnCurrencyOk_WhenHtmlHaveOneCurrency()
         {
             var dateTime = new DateTime(2020, 02, 04);
 
@@ -143,7 +143,7 @@ namespace Doppler.Currency.Test
 
             var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Ars);
 
-            Assert.Equal(dateTime.ToUniversalTime(), result.Entity.Date);
+            Assert.Equal("2020-02-04", result.Entity.Date);
         }
 
         [Fact]

--- a/Doppler.Currency.Test/BnaHandlerTests.cs
+++ b/Doppler.Currency.Test/BnaHandlerTests.cs
@@ -93,7 +93,7 @@ namespace Doppler.Currency.Test
 
             var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Ars);
 
-            Assert.Equal($"{dateTime:yyyy/MM/dd}", result.Entity.Date);
+            Assert.Equal(dateTime.ToUniversalTime(), result.Entity.Date);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Doppler.Currency.Test
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent($@"<div id='cotizacionesCercanas'>
+                    Content = new StringContent(@"<div id='cotizacionesCercanas'>
                     <table class='table table-bordered cotizador' style='float:none; width:100%; text-align: center;'>
                     <thead>
                     <tr>
@@ -143,7 +143,7 @@ namespace Doppler.Currency.Test
 
             var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Ars);
 
-            Assert.Equal($"{dateTime:yyyy/MM/dd}", result.Entity.Date);
+            Assert.Equal(dateTime.ToUniversalTime(), result.Entity.Date);
         }
 
         [Fact]

--- a/Doppler.Currency.Test/DofHandlerTests.cs
+++ b/Doppler.Currency.Test/DofHandlerTests.cs
@@ -80,7 +80,7 @@ namespace Doppler.Currency.Test
 
             var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Mxn);
             
-            Assert.Equal(dateTime.ToUniversalTime(), result.Entity.Date);
+            Assert.Equal("2020-02-05", result.Entity.Date);
         }
 
         [Fact]

--- a/Doppler.Currency.Test/DofHandlerTests.cs
+++ b/Doppler.Currency.Test/DofHandlerTests.cs
@@ -80,7 +80,7 @@ namespace Doppler.Currency.Test
 
             var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Mxn);
             
-            Assert.Equal($"{dateTime:yyyy/MM/dd}", result.Entity.Date);
+            Assert.Equal(dateTime.ToUniversalTime(), result.Entity.Date);
         }
 
         [Fact]

--- a/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
+++ b/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
@@ -22,12 +22,10 @@ namespace Doppler.Currency.Test.Integration
         }
 
         [Theory]
-        [InlineData("1-12-2012", "ARS")]
-        [InlineData("1-2-2012", "ars")]
+        [InlineData("1-2-2012", "ARS")]
         [InlineData("01-02-2012", "mxn")]
         [InlineData("01-2-2012", "MXN")]
         [InlineData("1-02-2012", "mXn")]
-        [InlineData("12-22-2010", "mxn")]
         public async Task GetCurrency_ShouldBeHttpStatusCodeOk_WhenDateAndCurrencyCodeAreCorrectly(string dateTime, string currencyCode)
         {
             //Arrange
@@ -50,10 +48,7 @@ namespace Doppler.Currency.Test.Integration
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotEmpty(responseString);
-
-            var dateString = DateTime.Parse(dateTime).ToUniversalTime();
-
-            Assert.Contains($"{dateString:yyyy-MM-dd}", responseString);
+            Assert.Contains("2012-01-02", responseString);
             Assert.Contains("30.34", responseString);
             Assert.Contains("10.3434", responseString);
         }

--- a/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
+++ b/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
@@ -36,8 +36,8 @@ namespace Doppler.Currency.Test.Integration
                     It.IsAny<CurrencyCodeEnum>()))
                 .ReturnsAsync(new EntityOperationResult<CurrencyDto>(new CurrencyDto
                 {
-                    BuyValue = "10",
-                    SaleValue = "30",
+                    BuyValue = 10.3434M,
+                    SaleValue = 30.34M,
                     Date = DateTime.Parse(dateTime).ToUniversalTime()
                 }));
 
@@ -54,8 +54,8 @@ namespace Doppler.Currency.Test.Integration
             var dateString = DateTime.Parse(dateTime).ToUniversalTime();
 
             Assert.Contains($"{dateString:yyyy-MM-dd}", responseString);
-            Assert.Contains("30", responseString);
-            Assert.Contains("10", responseString);
+            Assert.Contains("30.34", responseString);
+            Assert.Contains("10.3434", responseString);
         }
 
         [Fact]

--- a/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
+++ b/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
@@ -38,7 +38,7 @@ namespace Doppler.Currency.Test.Integration
                 {
                     BuyValue = 10.3434M,
                     SaleValue = 30.34M,
-                    Date = DateTime.Parse(dateTime).ToUniversalTime()
+                    Date = $"{DateTime.Parse(dateTime):yyyy-MM-dd}"
                 }));
 
             // Act

--- a/Doppler.Currency/Controllers/CurrencyController.cs
+++ b/Doppler.Currency/Controllers/CurrencyController.cs
@@ -24,19 +24,18 @@ namespace Doppler.Currency.Controllers
         [SwaggerResponse(200, "The currency is ok", typeof(CurrencyDto))]
         [SwaggerResponse(400, "The currency data is invalid")]
         public async Task<IActionResult> Get(
-            [SwaggerParameter(Description = "dd-MM-yyyy")] string date,
-            [SwaggerParameter(Description = "ARS, MXN")] CurrencyCodeEnum currencyCode)
+            [SwaggerParameter(Description = "yyyy-MM-dd")] DateTime date,
+            [SwaggerParameter(Description = "ARS=1, MXN=2")] CurrencyCodeEnum currencyCode)
         {
             _logger.LogInformation("Parsing dateTime");
-            DateTime.TryParse(date, out var dateTime);
 
-            if (dateTime.Year == 1 || dateTime.Date > DateTime.Now)
+            if (date.Year == 1 || date.Date > DateTime.Now)
             {
                 return BadRequest($"Invalid Date {date}");
             }
 
             _logger.LogInformation("Getting Usd currency");
-            var result = await _currencyService.GetCurrencyByCurrencyCodeAndDate(dateTime, currencyCode);
+            var result = await _currencyService.GetCurrencyByCurrencyCodeAndDate(date, currencyCode);
 
             if (result.Success)
                 return Ok(result);

--- a/Doppler.Currency/Dtos/CurrencyDto.cs
+++ b/Doppler.Currency/Dtos/CurrencyDto.cs
@@ -5,7 +5,7 @@ namespace Doppler.Currency.Dtos
 {
     public class CurrencyDto
     {
-        public DateTime Date { get; set; }
+        public string Date { get; set; }
 
         public decimal SaleValue { get; set; }
 

--- a/Doppler.Currency/Dtos/CurrencyDto.cs
+++ b/Doppler.Currency/Dtos/CurrencyDto.cs
@@ -7,10 +7,10 @@ namespace Doppler.Currency.Dtos
     {
         public DateTime Date { get; set; }
 
-        public string SaleValue { get; set; }
+        public decimal SaleValue { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string BuyValue { get; set; }
+        public decimal? BuyValue { get; set; }
         public string CurrencyName { get; set; } 
     }
 }

--- a/Doppler.Currency/Dtos/CurrencyDto.cs
+++ b/Doppler.Currency/Dtos/CurrencyDto.cs
@@ -1,10 +1,12 @@
+using System;
 using Newtonsoft.Json;
 
 namespace Doppler.Currency.Dtos
 {
     public class CurrencyDto
     {
-        public string Date { get; set; }
+        public DateTime Date { get; set; }
+
         public string SaleValue { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Doppler.Currency/Services/BnaHandler.cs
+++ b/Doppler.Currency/Services/BnaHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/Doppler.Currency/Services/BnaHandler.cs
+++ b/Doppler.Currency/Services/BnaHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -99,7 +100,7 @@ namespace Doppler.Currency.Services
             if (buyColumn != null && saleColumn != null && dateColumn != null)
             {
                 Logger.LogInformation("Creating Currency object to returned to the client.");
-                return CreateCurrency($"{date:yyyy/MM/dd}", saleColumn.InnerHtml, buyColumn.InnerHtml);
+                return CreateCurrency(date, saleColumn.InnerHtml, buyColumn.InnerHtml);
             }
 
             await SendSlackNotification(htmlPage, date, CurrencyCodeEnum.Ars);

--- a/Doppler.Currency/Services/CurrencyHandler.cs
+++ b/Doppler.Currency/Services/CurrencyHandler.cs
@@ -35,12 +35,12 @@ namespace Doppler.Currency.Services
         protected async Task SendSlackNotification(
             string htmlPage,
             DateTime dateTime,
-            CurrencyCodeEnum countryCode,
+            CurrencyCodeEnum currencyCode,
             Exception e = null)
         {
             Logger.LogError(e ?? new Exception("Error getting HTML"),
                 $"Error getting HTML, title is not valid, please check HTML: {htmlPage}");
-            await SlackHooksService.SendNotification(HttpClient, $"Can't get the USD currency from {countryCode} code country, please check Html in the log or if the date is holiday {dateTime}");
+            await SlackHooksService.SendNotification(HttpClient, $"Can't get currency from {currencyCode} currency code, please check Html in the log or if the date is holiday {dateTime.ToUniversalTime():yyyy-MM-dd}");
         }
 
         protected EntityOperationResult<CurrencyDto> CreateCurrency(DateTime date, string sale, string buy = null)

--- a/Doppler.Currency/Services/CurrencyHandler.cs
+++ b/Doppler.Currency/Services/CurrencyHandler.cs
@@ -42,11 +42,11 @@ namespace Doppler.Currency.Services
             await SlackHooksService.SendNotification(HttpClient, $"Can't get the USD currency from {countryCode} code country, please check Html in the log or if the date is holiday {dateTime}");
         }
 
-        protected EntityOperationResult<CurrencyDto> CreateCurrency(string date, string sale, string buy = null)
+        protected EntityOperationResult<CurrencyDto> CreateCurrency(DateTime date, string sale, string buy = null)
         {
             return new EntityOperationResult<CurrencyDto>(new CurrencyDto
             {
-                Date = date,
+                Date = date.ToUniversalTime(),
                 SaleValue = sale,
                 BuyValue = buy,
                 CurrencyName = ServiceSettings.CurrencyName

--- a/Doppler.Currency/Services/CurrencyHandler.cs
+++ b/Doppler.Currency/Services/CurrencyHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Net.Http;
 using System.Threading.Tasks;
 using CrossCutting;
@@ -44,11 +45,15 @@ namespace Doppler.Currency.Services
 
         protected EntityOperationResult<CurrencyDto> CreateCurrency(DateTime date, string sale, string buy = null)
         {
+            var cultureInfo = CultureInfo.CreateSpecificCulture("es-AR");
+            var saleDecimal = Convert.ToDecimal(sale, cultureInfo);
+            var buyDecimal = Convert.ToDecimal(buy, cultureInfo);
+
             return new EntityOperationResult<CurrencyDto>(new CurrencyDto
             {
                 Date = date.ToUniversalTime(),
-                SaleValue = sale,
-                BuyValue = buy,
+                SaleValue = saleDecimal,
+                BuyValue = buyDecimal == 0 ? (decimal?) null : buyDecimal,
                 CurrencyName = ServiceSettings.CurrencyName
             });
         }

--- a/Doppler.Currency/Services/CurrencyHandler.cs
+++ b/Doppler.Currency/Services/CurrencyHandler.cs
@@ -51,7 +51,7 @@ namespace Doppler.Currency.Services
 
             return new EntityOperationResult<CurrencyDto>(new CurrencyDto
             {
-                Date = date.ToUniversalTime(),
+                Date = $"{date.ToUniversalTime():yyyy-MM-dd}",
                 SaleValue = saleDecimal,
                 BuyValue = buyDecimal == 0 ? (decimal?) null : buyDecimal,
                 CurrencyName = ServiceSettings.CurrencyName

--- a/Doppler.Currency/Services/DofHandler.cs
+++ b/Doppler.Currency/Services/DofHandler.cs
@@ -69,7 +69,7 @@ namespace Doppler.Currency.Services
                         if (columnTime == $"{date:dd-MM-yyyy}")
                         {
                             var saleValue = columns.ElementAtOrDefault(3)?.InnerHtml.Replace(".", ",");
-                            return CreateCurrency($"{date:yyyy/MM/dd}", saleValue);
+                            return CreateCurrency(date, saleValue);
                         }
                     }
                 }

--- a/Doppler.Currency/Startup.cs
+++ b/Doppler.Currency/Startup.cs
@@ -117,10 +117,6 @@ namespace Doppler.Currency
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
-            var cultureInfo = new CultureInfo("es-AR");
-            CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
-            CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
-
             app.UseStaticFiles();
 
             loggerFactory.AddFile("Logs/app-{Date}.log");

--- a/Doppler.Currency/appsettings.json
+++ b/Doppler.Currency/appsettings.json
@@ -33,6 +33,6 @@
   },
   "SlackHook": {
     "Url": "[SECRET KEY]",
-    "Text": "Doppler Currency Service can't get the USD currency today, Please check Html format"
+    "Text": "Doppler Currency Service can't get the currency today, Please check Html format"
   } 
 }


### PR DESCRIPTION
# Background 
Now the sale and by values are returned as decimal and Date as an ISO format 

Ars
![image](https://user-images.githubusercontent.com/6796523/76646809-62e67380-653a-11ea-9891-7cdbb1f50cb2.png)

Mxn
![image](https://user-images.githubusercontent.com/6796523/76646842-72fe5300-653a-11ea-806b-9f8d1a30f8f6.png)


Can we review it?