### PR TITLE
Add currency code property in CurrencyResponse class

### DIFF
--- a/Doppler.Currency.Test/BnaHandlerTests.cs
+++ b/Doppler.Currency.Test/BnaHandlerTests.cs
@@ -32,8 +32,9 @@ namespace Doppler.Currency.Test
                 {
                     Url = "https://bna.com.ar/Cotizador/HistoricoPrincipales?id=billetes&filtroDolar=1&filtroEuro=0",
                     NoCurrency = "",
-                    CurrencyName = "",
-                    ValidationHtml = "Dolar U.S.A"
+                    CurrencyName = "Peso Argentino",
+                    ValidationHtml = "Dolar U.S.A",
+                    CurrencyCode = "ARS",
                 });
 
             _httpClientFactoryMock = new Mock<IHttpClientFactory>();
@@ -95,6 +96,10 @@ namespace Doppler.Currency.Test
             var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Ars);
 
             Assert.Equal("2020-02-05", result.Entity.Date);
+            Assert.Equal(58.0000M, result.Entity.BuyValue);
+            Assert.Equal(63.0000M, result.Entity.SaleValue);
+            Assert.Equal("Peso Argentino", result.Entity.CurrencyName);
+            Assert.Equal("ARS", result.Entity.CurrencyCode);
         }
 
         [Fact]

--- a/Doppler.Currency.Test/CurrencyServiceTests.cs
+++ b/Doppler.Currency.Test/CurrencyServiceTests.cs
@@ -34,7 +34,8 @@ namespace Doppler.Currency.Test
                     Url = "https://bna.com.ar/Cotizador/HistoricoPrincipales?id=billetes&filtroDolar=1&filtroEuro=0",
                     NoCurrency = "",
                     CurrencyName = "",
-                    ValidationHtml = "Dolar U.S.A"
+                    ValidationHtml = "Dolar U.S.A",
+                    CurrencyCode = "ARS"
                 });
 
             _httpClientFactoryMock = new Mock<IHttpClientFactory>();

--- a/Doppler.Currency.Test/DofHandlerTests.cs
+++ b/Doppler.Currency.Test/DofHandlerTests.cs
@@ -32,8 +32,9 @@ namespace Doppler.Currency.Test
                 {
                     Url = "http://www.dof.gob.mx/indicadores_detalle.php?cod_tipo_indicador=158",
                     NoCurrency = "",
-                    CurrencyName = "",
-                    ValidationHtml = "Dolar U.S.A"
+                    CurrencyName = "Peso Mexicano",
+                    ValidationHtml = "Dolar U.S.A",
+                    CurrencyCode = "MXN"
                 });
 
             _httpClientFactoryMock = new Mock<IHttpClientFactory>();
@@ -82,6 +83,9 @@ namespace Doppler.Currency.Test
             var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Mxn);
             
             Assert.Equal("2020-02-05", result.Entity.Date);
+            Assert.Equal(18.679700M, result.Entity.SaleValue);
+            Assert.Equal("Peso Mexicano", result.Entity.CurrencyName);
+            Assert.Equal("MXN", result.Entity.CurrencyCode);
         }
 
         [Fact]

--- a/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
+++ b/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
@@ -23,14 +23,15 @@ namespace Doppler.Currency.Test.Integration
         }
 
         [Theory]
-        [InlineData("1-2-2012", "ARS", "Peso Argentino")]
-        [InlineData("01-02-2012", "mxn", "Peso Mexicano")]
-        [InlineData("01-2-2012", "MXN", "Peso Mexicano")]
-        [InlineData("1-02-2012", "mXn", "Peso Mexicano")]
+        [InlineData("1-2-2012", "ArS", "Peso Argentino", "ARS")]
+        [InlineData("01-02-2012", "mxn", "Peso Mexicano", "MXN")]
+        [InlineData("01-2-2012", "MXN", "Peso Mexicano", "MXN")]
+        [InlineData("1-02-2012", "mXn", "Peso Mexicano", "MXM")]
         public async Task GetCurrency_ShouldBeHttpStatusCodeOk_WhenDateAndCurrencyCodeAreCorrectly(
             string dateTime, 
             string currencyCode,
-            string currencyName)
+            string currencyName,
+            string expectedCurrencyCode)
         {
             //Arrange
             _testServer.CurrencyServiceMock.Setup(x => x.GetCurrencyByCurrencyCodeAndDate(
@@ -41,7 +42,7 @@ namespace Doppler.Currency.Test.Integration
                     BuyValue = 10.3434M,
                     SaleValue = 30.34M,
                     Date = $"{DateTime.Parse(dateTime):yyyy-MM-dd}",
-                    CurrencyCode = currencyCode,
+                    CurrencyCode = expectedCurrencyCode,
                     CurrencyName = currencyName
                 }));
 
@@ -58,7 +59,7 @@ namespace Doppler.Currency.Test.Integration
             Assert.Equal("2012-01-02", result.Entity.Date);
             Assert.Equal(30.34M, result.Entity.SaleValue);
             Assert.Equal(10.3434M, result.Entity.BuyValue);
-            Assert.Equal(currencyCode, result.Entity.CurrencyCode);
+            Assert.Equal(expectedCurrencyCode, result.Entity.CurrencyCode);
             Assert.Equal(currencyName, result.Entity.CurrencyName);
         }
 

--- a/Doppler.Currency/Dtos/CurrencyDto.cs
+++ b/Doppler.Currency/Dtos/CurrencyDto.cs
@@ -10,6 +10,7 @@ namespace Doppler.Currency.Dtos
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public decimal? BuyValue { get; set; }
-        public string CurrencyName { get; set; } 
+        public string CurrencyName { get; set; }
+        public string CurrencyCode { get; set; }
     }
 }

--- a/Doppler.Currency/Services/BnaHandler.cs
+++ b/Doppler.Currency/Services/BnaHandler.cs
@@ -99,7 +99,8 @@ namespace Doppler.Currency.Services
             if (buyColumn != null && saleColumn != null && dateColumn != null)
             {
                 Logger.LogInformation("Creating Currency object to returned to the client.");
-                return CreateCurrency(date, saleColumn.InnerHtml, buyColumn.InnerHtml);
+                
+                return CreateCurrency(date, saleColumn.InnerHtml, CurrencyCodeEnum.Ars, buyColumn.InnerHtml);
             }
 
             await SendSlackNotification(htmlPage, date, CurrencyCodeEnum.Ars);

--- a/Doppler.Currency/Services/BnaHandler.cs
+++ b/Doppler.Currency/Services/BnaHandler.cs
@@ -100,7 +100,7 @@ namespace Doppler.Currency.Services
             {
                 Logger.LogInformation("Creating Currency object to returned to the client.");
                 
-                return CreateCurrency(date, saleColumn.InnerHtml, CurrencyCodeEnum.Ars, buyColumn.InnerHtml);
+                return CreateCurrency(date, saleColumn.InnerHtml, ServiceSettings.CurrencyCode, buyColumn.InnerHtml);
             }
 
             await SendSlackNotification(htmlPage, date, CurrencyCodeEnum.Ars);

--- a/Doppler.Currency/Services/CurrencyHandler.cs
+++ b/Doppler.Currency/Services/CurrencyHandler.cs
@@ -43,7 +43,11 @@ namespace Doppler.Currency.Services
             await SlackHooksService.SendNotification(HttpClient, $"Can't get currency from {currencyCode} currency code, please check Html in the log or if the date is holiday {dateTime.ToUniversalTime():yyyy-MM-dd}");
         }
 
-        protected EntityOperationResult<CurrencyDto> CreateCurrency(DateTime date, string sale, string buy = null)
+        protected EntityOperationResult<CurrencyDto> CreateCurrency(
+            DateTime date,
+            string sale,
+            CurrencyCodeEnum currencyCode,
+            string buy = null)
         {
             var cultureInfo = CultureInfo.CreateSpecificCulture("es-AR");
             var saleDecimal = Convert.ToDecimal(sale, cultureInfo);
@@ -54,7 +58,8 @@ namespace Doppler.Currency.Services
                 Date = $"{date.ToUniversalTime():yyyy-MM-dd}",
                 SaleValue = saleDecimal,
                 BuyValue = buyDecimal == 0 ? (decimal?) null : buyDecimal,
-                CurrencyName = ServiceSettings.CurrencyName
+                CurrencyName = ServiceSettings.CurrencyName,
+                CurrencyCode = currencyCode.ToString()
             });
         }
     }

--- a/Doppler.Currency/Services/CurrencyHandler.cs
+++ b/Doppler.Currency/Services/CurrencyHandler.cs
@@ -46,7 +46,7 @@ namespace Doppler.Currency.Services
         protected EntityOperationResult<CurrencyDto> CreateCurrency(
             DateTime date,
             string sale,
-            CurrencyCodeEnum currencyCode,
+            string currencyCode,
             string buy = null)
         {
             var cultureInfo = CultureInfo.CreateSpecificCulture("es-AR");
@@ -59,7 +59,7 @@ namespace Doppler.Currency.Services
                 SaleValue = saleDecimal,
                 BuyValue = buyDecimal == 0 ? (decimal?) null : buyDecimal,
                 CurrencyName = ServiceSettings.CurrencyName,
-                CurrencyCode = currencyCode.ToString()
+                CurrencyCode = currencyCode.ToUpper()
             });
         }
     }

--- a/Doppler.Currency/Services/DofHandler.cs
+++ b/Doppler.Currency/Services/DofHandler.cs
@@ -69,7 +69,7 @@ namespace Doppler.Currency.Services
                         if (columnTime == $"{date:dd-MM-yyyy}")
                         {
                             var saleValue = columns.ElementAtOrDefault(3)?.InnerHtml.Replace(".", ",");
-                            return CreateCurrency(date, saleValue);
+                            return CreateCurrency(date, saleValue, CurrencyCodeEnum.Mxn);
                         }
                     }
                 }

--- a/Doppler.Currency/Services/DofHandler.cs
+++ b/Doppler.Currency/Services/DofHandler.cs
@@ -69,7 +69,7 @@ namespace Doppler.Currency.Services
                         if (columnTime == $"{date:dd-MM-yyyy}")
                         {
                             var saleValue = columns.ElementAtOrDefault(3)?.InnerHtml.Replace(".", ",");
-                            return CreateCurrency(date, saleValue, CurrencyCodeEnum.Mxn);
+                            return CreateCurrency(date, saleValue, ServiceSettings.CurrencyCode);
                         }
                     }
                 }

--- a/Doppler.Currency/Settings/CurrencySettings.cs
+++ b/Doppler.Currency/Settings/CurrencySettings.cs
@@ -6,5 +6,6 @@
         public string ValidationHtml { get; set; }
         public string NoCurrency { get; set; }
         public string CurrencyName { get; set; }
+        public string CurrencyCode { get; set; }
     }
 }


### PR DESCRIPTION
# Background
Add `currencyCode ` property in the result, because of Doppler Sap need it

![image](https://user-images.githubusercontent.com/6796523/77582675-7db3d300-6ebe-11ea-9cff-dbb104dec041.png)

Can you review it?