### PR TITLE
Make optional Slack Hook service

### DIFF
--- a/CrossCutting/CrossCutting.csproj
+++ b/CrossCutting/CrossCutting.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
   </ItemGroup>
 

--- a/CrossCutting/SlackHooksService/DummySlackHooksService.cs
+++ b/CrossCutting/SlackHooksService/DummySlackHooksService.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace CrossCutting.SlackHooksService
+{
+    public class DummySlackHooksService : ISlackHooksService
+    {
+        private readonly ILogger<ISlackHooksService> _slackHookLogger;
+        public DummySlackHooksService(ILogger<ISlackHooksService> slackHookLogger)
+        {
+            _slackHookLogger = slackHookLogger;
+        }
+
+        public Task SendNotification(string message = null)
+        {
+            _slackHookLogger.LogInformation("Non-existent Settings for Slack hook service.");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/CrossCutting/SlackHooksService/ISlackHooksService.cs
+++ b/CrossCutting/SlackHooksService/ISlackHooksService.cs
@@ -1,10 +1,9 @@
-﻿using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace CrossCutting.SlackHooksService
 {
     public interface ISlackHooksService
     {
-        public Task<HttpResponseMessage> SendNotification(HttpClient httpClient, string message = null);
+        public Task SendNotification(string message = null);
     }
 }

--- a/CrossCutting/SlackHooksService/SlackHooksService.cs
+++ b/CrossCutting/SlackHooksService/SlackHooksService.cs
@@ -14,10 +14,13 @@ namespace CrossCutting.SlackHooksService
     {
         private readonly JsonSerializerSettings _serializationSettings;
         private readonly SlackHookSettings _slackHookSettings;
+        private readonly HttpClient _httpClient;
 
-        public SlackHooksService(SlackHookSettings slackHookSettings)
+        public SlackHooksService(SlackHookSettings slackHookSettings, IHttpClientFactory httpClientFactory)
         {
             _slackHookSettings = slackHookSettings;
+            _httpClient = httpClientFactory.CreateClient();
+
             _serializationSettings = new JsonSerializerSettings
             {
                 Formatting = Formatting.Indented,
@@ -33,24 +36,23 @@ namespace CrossCutting.SlackHooksService
             };
         }
 
-        public async Task<HttpResponseMessage> SendNotification(HttpClient httpClient, string message = null)
+        public async Task SendNotification(string message = null)
         {
             var payloadData = new
-            {
-                text = !string.IsNullOrEmpty(message) ? message : _slackHookSettings.Text
-            };
+                {
+                    text = !string.IsNullOrEmpty(message) ? message : _slackHookSettings.Text
+                };
 
-            var builder = new UriBuilder(_slackHookSettings.Url);
+                var builder = new UriBuilder(_slackHookSettings.Url);
 
-            var httpRequest = new HttpRequestMessage { RequestUri = builder.Uri, Method = new HttpMethod("POST") };
+                var httpRequest = new HttpRequestMessage {RequestUri = builder.Uri, Method = new HttpMethod("POST")};
 
-            var requestContent = SafeJsonConvert.SerializeObject(JObject.FromObject(payloadData), _serializationSettings);
-            httpRequest.Content = new StringContent(requestContent, Encoding.UTF8);
-            httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                var requestContent =
+                    SafeJsonConvert.SerializeObject(JObject.FromObject(payloadData), _serializationSettings);
+                httpRequest.Content = new StringContent(requestContent, Encoding.UTF8);
+                httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
 
-            var httpResponse = await httpClient.SendAsync(httpRequest).ConfigureAwait(false);
-
-            return httpResponse;
+                await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
         }
     }
 }

--- a/Doppler.Currency.Test/BnaHandlerTests.cs
+++ b/Doppler.Currency.Test/BnaHandlerTests.cs
@@ -168,7 +168,6 @@ namespace Doppler.Currency.Test
 
             var slackHooksServiceMock = new Mock<ISlackHooksService>();
             slackHooksServiceMock.Setup(x => x.SendNotification(
-                    It.IsAny<HttpClient>(),
                     It.IsAny<string>()))
                 .Verifiable();
 
@@ -185,9 +184,7 @@ namespace Doppler.Currency.Test
             await service.GetCurrencyByCurrencyCodeAndDate(DateTime.Now, CurrencyCodeEnum.Ars);
 
             slackHooksServiceMock.Verify(x => x.SendNotification(
-                    It.IsAny<HttpClient>(),
-                    It.IsAny<string>()),
-                Times.Once);
+                    It.IsAny<string>()), Times.Once);
         }
 
         [Fact]
@@ -217,7 +214,7 @@ namespace Doppler.Currency.Test
                 .Returns(_httpClient);
 
             var slackHooksServiceMock = new Mock<ISlackHooksService>();
-            slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<HttpClient>(), It.IsAny<string>()))
+            slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<string>()))
                 .Verifiable();
 
             var service = CreateSutCurrencyService.CreateSut(
@@ -232,9 +229,7 @@ namespace Doppler.Currency.Test
 
             var result = await service.GetCurrencyByCurrencyCodeAndDate(DateTime.Now, CurrencyCodeEnum.Ars);
 
-            slackHooksServiceMock.Verify(x => x.SendNotification(
-                It.IsAny<HttpClient>(),
-                It.IsAny<string>()), Times.Never);
+            slackHooksServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Never);
 
             Assert.False(result.Success);
             Assert.Equal(1, result.Errors.Count);
@@ -273,7 +268,6 @@ namespace Doppler.Currency.Test
 
             var slackHooksServiceMock = new Mock<ISlackHooksService>();
             slackHooksServiceMock.Setup(x => x.SendNotification(
-                    It.IsAny<HttpClient>(),
                     It.IsAny<string>()))
                 .Verifiable();
 
@@ -290,7 +284,6 @@ namespace Doppler.Currency.Test
             var result = await service.GetCurrencyByCurrencyCodeAndDate(DateTime.UtcNow.AddYears(1), CurrencyCodeEnum.Ars);
 
             slackHooksServiceMock.Verify(x => x.SendNotification(
-                It.IsAny<HttpClient>(),
                 It.IsAny<string>()), Times.Never);
 
             Assert.Equal(1, result.Errors.Count);
@@ -327,7 +320,7 @@ namespace Doppler.Currency.Test
                 .Returns(_httpClient);
 
             var slackHooksServiceMock = new Mock<ISlackHooksService>();
-            slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<HttpClient>(), It.IsAny<string>()))
+            slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<string>()))
                 .Verifiable();
 
             var loggerMock = new Mock<ILogger<CurrencyHandler>>();

--- a/Doppler.Currency.Test/DofHandlerTests.cs
+++ b/Doppler.Currency.Test/DofHandlerTests.cs
@@ -120,7 +120,7 @@ namespace Doppler.Currency.Test
                 .Returns(_httpClient);
 
             var slackHooksServiceMock = new Mock<ISlackHooksService>();
-            slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<HttpClient>(), It.IsAny<string>()))
+            slackHooksServiceMock.Setup(x => x.SendNotification( It.IsAny<string>()))
                 .Verifiable();
 
             var service = CreateSutCurrencyService.CreateSut(
@@ -137,8 +137,7 @@ namespace Doppler.Currency.Test
 
             Assert.False(result.Success);
             slackHooksServiceMock.Verify(x => x.SendNotification(
-                It.IsAny<HttpClient>(),
-                It.IsAny<string>()), 
+                    It.IsAny<string>()), 
                 Times.Once);
         }
 
@@ -169,7 +168,7 @@ namespace Doppler.Currency.Test
                 .Returns(_httpClient);
 
             var slackHooksServiceMock = new Mock<ISlackHooksService>();
-            slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<HttpClient>(), It.IsAny<string>()))
+            slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<string>()))
                 .Verifiable();
 
             var service = CreateSutCurrencyService.CreateSut(
@@ -187,8 +186,7 @@ namespace Doppler.Currency.Test
             Assert.False(result.Success);
 
             slackHooksServiceMock.Verify(x => x.SendNotification(
-                It.IsAny<HttpClient>(), 
-                It.IsAny<string>()),
+                    It.IsAny<string>()),
                 Times.Once);
 
             Assert.Equal(1, result.Errors.Count);
@@ -228,7 +226,7 @@ namespace Doppler.Currency.Test
                 .Returns(_httpClient);
 
             var slackHooksServiceMock = new Mock<ISlackHooksService>();
-            slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<HttpClient>(), It.IsAny<string>()))
+            slackHooksServiceMock.Setup(x => x.SendNotification( It.IsAny<string>()))
                 .Verifiable();
 
             var loggerMock = new Mock<ILogger<CurrencyHandler>>();

--- a/Doppler.Currency/Program.cs
+++ b/Doppler.Currency/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 
@@ -15,6 +16,11 @@ namespace Doppler.Currency
             Host.CreateDefaultBuilder(args)
                 .UseSerilog((hostContext, loggerConfiguration) => 
                     loggerConfiguration.ReadFrom.Configuration(hostContext.Configuration))
+                .ConfigureAppConfiguration(configHost =>
+                {
+                    configHost.AddJsonFile("/run/secrets/appsettings.Secret.json", true);
+                    configHost.AddKeyPerFile("/run/secrets", true);
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/Doppler.Currency/Services/BnaHandler.cs
+++ b/Doppler.Currency/Services/BnaHandler.cs
@@ -29,7 +29,6 @@ namespace Doppler.Currency.Services
 
         public override async Task<EntityOperationResult<CurrencyDto>> Handle(DateTime date)
         {
-            // Construct URL
             Logger.LogInformation("building url to get html data.");
             var dateUrl = System.Web.HttpUtility.UrlEncode($"{date:dd/MM/yyyy}");
 

--- a/Doppler.Currency/Services/CurrencyHandler.cs
+++ b/Doppler.Currency/Services/CurrencyHandler.cs
@@ -39,8 +39,8 @@ namespace Doppler.Currency.Services
             Exception e = null)
         {
             Logger.LogError(e ?? new Exception("Error getting HTML"),
-                $"Error getting HTML, title is not valid, please check HTML: {htmlPage}");
-            await SlackHooksService.SendNotification(HttpClient, $"Can't get currency from {currencyCode} currency code, please check Html in the log or if the date is holiday {dateTime.ToUniversalTime():yyyy-MM-dd}");
+                    $"Error getting HTML, title is not valid, please check HTML: {htmlPage}");
+                await SlackHooksService.SendNotification($"Can't get currency from {currencyCode} currency code, please check Html in the log or if the date is holiday {dateTime.ToUniversalTime():yyyy-MM-dd}");
         }
 
         protected CurrencyDto CreateCurrency(

--- a/Doppler.Currency/SlackHookServiceCollectionExtensions.cs
+++ b/Doppler.Currency/SlackHookServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Net.Http;
+using CrossCutting;
+using CrossCutting.SlackHooksService;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Doppler.Currency
+{
+    public static class SlackHookServiceCollectionExtensions
+    {
+        public static IServiceCollection AddSlackHook(this IServiceCollection services)
+        {
+            services.AddSingleton<ISlackHooksService>(provider =>
+            {
+                var configuration = provider.GetService<IConfiguration>();
+                var section = configuration.GetSection("SlackHook");
+
+                if (!section.Exists()) 
+                    return new DummySlackHooksService(provider.GetService<ILogger<DummySlackHooksService>>());
+
+                var slackHookSettings = new SlackHookSettings();
+                section.Bind(slackHookSettings);
+
+                return new SlackHooksService(slackHookSettings, provider.GetService<IHttpClientFactory>());
+
+            });
+
+            return services;
+        }
+    }
+}

--- a/Doppler.Currency/Startup.cs
+++ b/Doppler.Currency/Startup.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Authentication;
-using CrossCutting;
-using CrossCutting.SlackHooksService;
 using Doppler.Currency.Enums;
 using Doppler.Currency.Services;
 using Doppler.Currency.Settings;
@@ -65,9 +63,7 @@ namespace Doppler.Currency
 
             services.AddTransient<ICurrencyService, CurrencyService>();
 
-            AddServiceSettings(services);
-
-            services.AddTransient<ISlackHooksService, SlackHooksService>();
+            services.AddSlackHook();
 
             services.AddTransient<DofHandler>();
             services.AddTransient<BnaHandler>();
@@ -77,21 +73,6 @@ namespace Doppler.Currency
                     { CurrencyCodeEnum.Ars, sp.GetRequiredService<BnaHandler>() },
                     { CurrencyCodeEnum.Mxn, sp.GetRequiredService<DofHandler>() }
                 });
-        }
-
-        private void AddServiceSettings(IServiceCollection services)
-        {
-            var dofSettings = new CurrencySettings();
-            Configuration.GetSection("CurrencyCode:DofService").Bind(dofSettings);
-            services.AddSingleton(dofSettings);
-
-            var bnaSettings = new CurrencySettings();
-            Configuration.GetSection("CurrencyCode:BnaService").Bind(bnaSettings);
-            services.AddSingleton(bnaSettings);
-
-            var slackHookSettings = new SlackHookSettings();
-            Configuration.GetSection("SlackHook").Bind(slackHookSettings);
-            services.AddSingleton(slackHookSettings);
         }
 
         private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy(int retry)
@@ -120,8 +101,6 @@ namespace Doppler.Currency
             }
 
             app.UseRouting();
-
-            app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {

--- a/Doppler.Currency/appsettings.json
+++ b/Doppler.Currency/appsettings.json
@@ -43,9 +43,10 @@
       "CurrencyCode": "MXN",
       "CurrencyName": "Peso Mexicano"
     }
-  },
-  "SlackHook": {
-    "Url": "[SECRET KEY]",
-    "Text": "Doppler Currency Service can't get the currency today, Please check Html format"
   }
+  /* Add Property SlackHook if you want Slack integration
+    "SlackHook": {
+      "Url": "",
+      "Text": ""
+    }*/
 }


### PR DESCRIPTION
# Background
We need to make optional the slack hook service because this API should not fail when settings for Slack hook service is not deployed

# Additional changes
- Add DummySlackHooksService.cs when not exist Slack settings
- Slack hook service now has an `IHttpFactory `
- Improvements in Startup.cs

# Settings
If you want Slack integration, can add the key appsettings.json
```
"SlackHook": {
      "Url": "",
      "Text": ""
}