### PR TITLE
Add json file configuration for secrets keys

### DIFF
--- a/Doppler.Currency/Program.cs
+++ b/Doppler.Currency/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 
@@ -15,6 +16,11 @@ namespace Doppler.Currency
             Host.CreateDefaultBuilder(args)
                 .UseSerilog((hostContext, loggerConfiguration) => 
                     loggerConfiguration.ReadFrom.Configuration(hostContext.Configuration))
+                .ConfigureAppConfiguration(configHost =>
+                {
+                    configHost.AddJsonFile("/run/secrets/appsettings.Secret.json", true);
+                    configHost.AddKeyPerFile("/run/secrets", true);
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();


### PR DESCRIPTION
# Background
We created a new stack in this [pr]( https://github.com/MakingSense/doppler-swarm/pull/65) for Docker Swarm, It this was added for Doppler.Currency API and Docker Swarm about Secret Keys
Used from [link](https://github.com/MakingSense/doppler-forms/blob/master/DopplerForms/Program.cs#L23)
Can you review it?