### PR TITLE
Create HttpClient object when is used

### DIFF
--- a/Doppler.Currency/Services/BnaHandler.cs
+++ b/Doppler.Currency/Services/BnaHandler.cs
@@ -22,7 +22,7 @@ namespace Doppler.Currency.Services
             HttpClientPoliciesSettings bnaClientPoliciesSettings,
             IOptionsMonitor<CurrencySettings> bnaSettings,
             ISlackHooksService slackHooksService,
-            ILogger<CurrencyHandler> logger) : base(httpClientFactory.CreateClient(bnaClientPoliciesSettings.ClientName),
+            ILogger<CurrencyHandler> logger) : base(httpClientFactory, bnaClientPoliciesSettings,
             bnaSettings.Get("BnaService"), slackHooksService, logger)
         {
         }
@@ -42,7 +42,8 @@ namespace Doppler.Currency.Services
             };
 
             Logger.LogInformation("Sending request to Bna server.");
-            var httpResponse = await HttpClient.SendAsync(httpRequest).ConfigureAwait(false);
+            var client = HttpClientFactory.CreateClient(HttpClientPoliciesSettings.ClientName);
+            var httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
 
             Logger.LogInformation("Getting Html content of the Bna.");
             var htmlPage = await httpResponse.Content.ReadAsStringAsync();

--- a/Doppler.Currency/Services/CurrencyHandler.cs
+++ b/Doppler.Currency/Services/CurrencyHandler.cs
@@ -13,18 +13,21 @@ namespace Doppler.Currency.Services
 {
     public abstract class CurrencyHandler
     {
-        protected readonly HttpClient HttpClient;
+        protected readonly IHttpClientFactory HttpClientFactory;
         protected readonly CurrencySettings ServiceSettings;
         protected readonly ISlackHooksService SlackHooksService;
         protected readonly ILogger<CurrencyHandler> Logger;
+        protected readonly HttpClientPoliciesSettings HttpClientPoliciesSettings;
 
         protected CurrencyHandler(
-            HttpClient httpClient,
+            IHttpClientFactory httpClientFactory,
+            HttpClientPoliciesSettings httpClientPoliciesSettings,
             CurrencySettings serviceSettings,
             ISlackHooksService slackHooksService, 
             ILogger<CurrencyHandler> logger)
         {
-            HttpClient = httpClient;
+            HttpClientFactory = httpClientFactory;
+            HttpClientPoliciesSettings = httpClientPoliciesSettings;
             ServiceSettings = serviceSettings;
             SlackHooksService = slackHooksService;
             Logger = logger;

--- a/Doppler.Currency/Services/DofHandler.cs
+++ b/Doppler.Currency/Services/DofHandler.cs
@@ -20,7 +20,7 @@ namespace Doppler.Currency.Services
             HttpClientPoliciesSettings dofClientPoliciesSettings,
             IOptionsMonitor<CurrencySettings> dofSettings,
             ISlackHooksService slackHooksService,
-            ILogger<CurrencyHandler> logger) : base(httpClientFactory.CreateClient(dofClientPoliciesSettings.ClientName), dofSettings.Get("DofService"),
+            ILogger<CurrencyHandler> logger) : base(httpClientFactory, dofClientPoliciesSettings, dofSettings.Get("DofService"),
             slackHooksService, logger)
         {
         }
@@ -41,7 +41,8 @@ namespace Doppler.Currency.Services
             };
 
             Logger.LogInformation("Sending request to Bna server.");
-            var httpResponse = await HttpClient.SendAsync(httpRequest).ConfigureAwait(false);
+            var client = HttpClientFactory.CreateClient(HttpClientPoliciesSettings.ClientName);
+            var httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
 
             Logger.LogInformation("Getting Html content of the Bna.");
             var htmlPage = await httpResponse.Content.ReadAsStringAsync();


### PR DESCRIPTION
# Background
We use IHttpClientFactory, the default handler lifetime is two minutes, see [link](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1#httpclient-and-lifetime-management)
I moved `HttpClientFactory.CreateClient()` when is used

can you review it?