### PR TITLE
Add Colombia currency

### DIFF
--- a/CrossCutting/EntityOperationResult.cs
+++ b/CrossCutting/EntityOperationResult.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CrossCutting
 {
+    [ExcludeFromCodeCoverage]
     public class EntityOperationResult<TEntity> where TEntity : class
     {
         public TEntity Entity { get; set; }

--- a/CrossCutting/SlackHookSettings.cs
+++ b/CrossCutting/SlackHookSettings.cs
@@ -1,5 +1,8 @@
-﻿namespace CrossCutting
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace CrossCutting
 {
+    [ExcludeFromCodeCoverage]
     public class SlackHookSettings
     {
         public string Url { get; set; }

--- a/CrossCutting/SlackHooksService/DummySlackHooksService.cs
+++ b/CrossCutting/SlackHooksService/DummySlackHooksService.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace CrossCutting.SlackHooksService
 {
+    [ExcludeFromCodeCoverage]
     public class DummySlackHooksService : ISlackHooksService
     {
         private readonly ILogger<ISlackHooksService> _slackHookLogger;

--- a/CrossCutting/SlackHooksService/SlackHooksService.cs
+++ b/CrossCutting/SlackHooksService/SlackHooksService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Rest.Serialization;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -10,6 +11,7 @@ using Newtonsoft.Json.Linq;
 
 namespace CrossCutting.SlackHooksService
 {
+    [ExcludeFromCodeCoverage]
     public class SlackHooksService : ISlackHooksService
     {
         private readonly JsonSerializerSettings _serializationSettings;

--- a/Doppler.Currency.Test/CurrencyServiceTests.cs
+++ b/Doppler.Currency.Test/CurrencyServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -18,6 +19,7 @@ using Xunit;
 
 namespace Doppler.Currency.Test
 {
+    [ExcludeFromCodeCoverage]
     public class CurrencyServiceTests
     {
         private readonly Mock<IOptionsMonitor<CurrencySettings>> _mockUsdCurrencySettings;
@@ -70,11 +72,14 @@ namespace Doppler.Currency.Test
 
             Enum.TryParse(typeof(CurrencyCodeEnum), currencyCode, true, out var parseResult);
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(new DateTime(2020, 2, 4), (CurrencyCodeEnum) parseResult);
+            if (parseResult != null)
+            {
+                var result = await service.GetCurrencyByCurrencyCodeAndDate(new DateTime(2020, 2, 4), (CurrencyCodeEnum) parseResult);
 
-            Assert.True(result.Success);
-            Assert.Equal(0, result.Errors.Count);
-            Assert.False(result.Errors.ContainsKey("Currency code invalid"));
+                Assert.True(result.Success);
+                Assert.Equal(0, result.Errors.Count);
+                Assert.False(result.Errors.ContainsKey("Currency code invalid"));
+            }
         }
 
         public class CalculatorTestData : IEnumerable<object[]>

--- a/Doppler.Currency.Test/Integration/CreateSutCurrencyService.cs
+++ b/Doppler.Currency.Test/Integration/CreateSutCurrencyService.cs
@@ -17,30 +17,37 @@ namespace Doppler.Currency.Test.Integration
         public static CurrencyService CreateSut(
             IHttpClientFactory httpClientFactory = null,
             HttpClientPoliciesSettings httpClientPoliciesSettings = null,
-            IOptionsMonitor<CurrencySettings> bnaSettings = null,
+            IOptionsMonitor<CurrencySettings> currencySettings = null,
             ISlackHooksService slackHooksService = null,
             ILogger<CurrencyHandler> loggerHandler = null,
-            ILogger<CurrencyService> loggerService = null,
-            ILogger<DofHandler> loggerDof = null)
+            ILogger<CurrencyService> loggerService = null)
         {
             var bnaHandler = new BnaHandler(
                 httpClientFactory,
                 httpClientPoliciesSettings,
-                bnaSettings,
+                currencySettings,
                 slackHooksService,
                 loggerHandler ?? Mock.Of<ILogger<CurrencyHandler>>());
 
             var dofHandler = new DofHandler(
                 httpClientFactory,
                 httpClientPoliciesSettings,
-                bnaSettings,
+                currencySettings,
+                slackHooksService,
+                loggerHandler ?? Mock.Of<ILogger<CurrencyHandler>>());
+
+            var trmHandler= new TrmHandler(
+                httpClientFactory,
+                httpClientPoliciesSettings,
+                currencySettings,
                 slackHooksService,
                 loggerHandler ?? Mock.Of<ILogger<CurrencyHandler>>());
 
             var handler = new Dictionary<CurrencyCodeEnum, CurrencyHandler>
             {
                 { CurrencyCodeEnum.Ars, bnaHandler },
-                { CurrencyCodeEnum.Mxn, dofHandler }
+                { CurrencyCodeEnum.Mxn, dofHandler },
+                { CurrencyCodeEnum.Cop, trmHandler }
             };
 
             return new CurrencyService(

--- a/Doppler.Currency.Test/Integration/CreateSutCurrencyService.cs
+++ b/Doppler.Currency.Test/Integration/CreateSutCurrencyService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using CrossCutting.SlackHooksService;
 using Doppler.Currency.Enums;
@@ -10,6 +11,7 @@ using Moq;
 
 namespace Doppler.Currency.Test.Integration
 {
+    [ExcludeFromCodeCoverage]
     public static class CreateSutCurrencyService
     {
         public static CurrencyService CreateSut(

--- a/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
+++ b/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
@@ -71,6 +71,24 @@ namespace Doppler.Currency.Test.Integration
         }
 
         [Fact]
+        public async Task GetCurrency_ShouldBeHttpStatusCodeBadRequest_WhenResponseReturnAnError()
+        {
+            //Arrange
+            var result = new EntityOperationResult<CurrencyDto>();
+            result.AddError("","");
+            _testServer.CurrencyServiceMock.Setup(x => x.GetCurrencyByCurrencyCodeAndDate(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<CurrencyCodeEnum>()))
+                .ReturnsAsync(result);
+
+            // Act
+            var response = await _client.GetAsync("Currency/Ars/01-02-2012");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
         public async Task GetCurrency_ShouldBeHttpStatusCodeNotFound_WhenUrlDoesNotHaveDateTime()
         {
             // Act
@@ -107,6 +125,17 @@ namespace Doppler.Currency.Test.Integration
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
+        }
+
+        [Fact]
+        public async Task GetCurrency_ShouldBeHttpStatusCodeBadRequest_WhenDateIsMajorThatDateNow()
+        {
+            // Act
+            var response = await _client.GetAsync("Currency/1/02-02-2550");
+
+            // Assert
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [Theory]

--- a/Doppler.Currency.Test/TrmHandlerTest.cs
+++ b/Doppler.Currency.Test/TrmHandlerTest.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using CrossCutting.SlackHooksService;
+using Doppler.Currency.Enums;
+using Doppler.Currency.Services;
+using Doppler.Currency.Settings;
+using Doppler.Currency.Test.Integration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Doppler.Currency.Test
+{
+    public class TrmHandlerTest
+    {
+        private readonly Mock<IOptionsMonitor<CurrencySettings>> _mockUsdCurrencySettings;
+        private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock;
+        private readonly HttpClient _httpClient;
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+
+        public TrmHandlerTest()
+        {
+            _mockUsdCurrencySettings = new Mock<IOptionsMonitor<CurrencySettings>>();
+            _mockUsdCurrencySettings.Setup(x => x.Get(It.IsAny<string>()))
+                .Returns(new CurrencySettings
+                {
+                    Url = "https://www.datos.gov.co/resource/ceyp-9c7c.json?VIGENCIAHASTA=",
+                    NoCurrency = "",
+                    CurrencyName = "Peso Colombiano",
+                    CurrencyCode = "COP",
+                });
+            _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            _httpClient = new HttpClient(_httpMessageHandlerMock.Object);
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        }
+
+        [Fact]
+        public async Task GetCurrency_ShouldBeReturnCurrencyOk_WhenTrmHasInformation()
+        {
+            var dateTime = new DateTime(2020, 02, 05);
+
+            _httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("[{\"valor\":\"3783.15\",\"vigenciadesde\":\"2020-02-05T00: 00:00.000\",\"vigenciahasta\":\"2020-02-05T00: 00:00.000\"}]")
+                });
+
+            _httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(_httpClient);
+
+            var service = CreateSutCurrencyService.CreateSut(
+                _httpClientFactoryMock.Object,
+                new HttpClientPoliciesSettings
+                {
+                    ClientName = "test"
+                },
+                _mockUsdCurrencySettings.Object,
+                Mock.Of<ISlackHooksService>(),
+                Mock.Of<ILogger<CurrencyHandler>>());
+
+            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Cop);
+
+            Assert.Equal("2020-02-05", result.Entity.Date);
+            Assert.Equal("Peso Colombiano", result.Entity.CurrencyName);
+            Assert.Equal("COP", result.Entity.CurrencyCode);
+        }
+
+        [Fact]
+        public async Task GetCurrency_ShouldBeSendSlackNotification_WhenTrmDoesNotHaveInformation()
+        {
+            var dateTime = new DateTime(2020, 02, 05);
+
+            _httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("")
+                });
+
+            _httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(_httpClient);
+
+            var slackHookServiceMock = new Mock<ISlackHooksService>();
+            var service = CreateSutCurrencyService.CreateSut(
+                _httpClientFactoryMock.Object,
+                new HttpClientPoliciesSettings
+                {
+                    ClientName = "test"
+                },
+                _mockUsdCurrencySettings.Object,
+                slackHookServiceMock.Object,
+                Mock.Of<ILogger<CurrencyHandler>>());
+
+            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Cop);
+
+           Assert.Null(result.Entity);
+           Assert.Equal(1, result.Errors.Count);
+           slackHookServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/Doppler.Currency/Controllers/CurrencyController.cs
+++ b/Doppler.Currency/Controllers/CurrencyController.cs
@@ -27,11 +27,11 @@ namespace Doppler.Currency.Controllers
         [SwaggerResponse(400, "The currency data is invalid")]
         public async Task<IActionResult> Get(
             [SwaggerParameter(Description = "yyyy-MM-dd")] DateTime date,
-            [SwaggerParameter(Description = "ARS=1, MXN=2")] CurrencyCodeEnum currencyCode)
+            [SwaggerParameter(Description = "ARS=1, MXN=2, COP=3")] CurrencyCodeEnum currencyCode)
         {
             _logger.LogInformation("Parsing dateTime");
 
-            if (date.Year == 1 || date.Date > DateTime.Now)
+            if (date.Date > DateTime.Now)
             {
                 return BadRequest($"Invalid Date {date}");
             }

--- a/Doppler.Currency/Enums/CurrencyCodeEnum.cs
+++ b/Doppler.Currency/Enums/CurrencyCodeEnum.cs
@@ -9,6 +9,8 @@ namespace Doppler.Currency.Enums
         [JsonProperty("ars")]
         Ars = 1,
         [JsonProperty("mxn")]
-        Mxn = 2
+        Mxn = 2,
+        [JsonProperty("cop")]
+        Cop =3
     }
 }

--- a/Doppler.Currency/Enums/CurrencyCodeEnum.cs
+++ b/Doppler.Currency/Enums/CurrencyCodeEnum.cs
@@ -11,6 +11,6 @@ namespace Doppler.Currency.Enums
         [JsonProperty("mxn")]
         Mxn = 2,
         [JsonProperty("cop")]
-        Cop =3
+        Cop = 3
     }
 }

--- a/Doppler.Currency/Program.cs
+++ b/Doppler.Currency/Program.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -5,6 +6,7 @@ using Serilog;
 
 namespace Doppler.Currency
 {
+    [ExcludeFromCodeCoverage]
     public class Program
     {
         public static void Main(string[] args)

--- a/Doppler.Currency/Services/TrmHandler.cs
+++ b/Doppler.Currency/Services/TrmHandler.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CrossCutting;
+using CrossCutting.SlackHooksService;
+using Doppler.Currency.Dtos;
+using Doppler.Currency.Enums;
+using Doppler.Currency.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace Doppler.Currency.Services
+{
+    public class TrmHandler : CurrencyHandler
+    {
+        public TrmHandler(
+            IHttpClientFactory httpClientFactory, 
+            HttpClientPoliciesSettings httpClientPoliciesSettings,
+            IOptionsMonitor<CurrencySettings> serviceSettings, 
+            ISlackHooksService slackHooksService, 
+            ILogger<CurrencyHandler> logger) : base(httpClientFactory, httpClientPoliciesSettings, serviceSettings.Get("TrmService"), slackHooksService, logger) { }
+
+        public override async Task<EntityOperationResult<CurrencyDto>> Handle(DateTime date)
+        {
+            // Construct URL
+            Logger.LogInformation("building url to get html data.");
+            var dateUrl = System.Web.HttpUtility.UrlEncode($"{date:yyyy-MM-dd}");
+            var uri = new Uri($"{ServiceSettings.Url}{dateUrl}");
+
+            Logger.LogInformation("Building http request with url {uri}", uri);
+            var httpRequest = new HttpRequestMessage
+            {
+                RequestUri = uri,
+                Method = new HttpMethod("GET")
+            };
+
+            Logger.LogInformation("Sending request to Bna server.");
+            var client = HttpClientFactory.CreateClient();
+            var httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
+
+            Logger.LogInformation("Getting Html content of the Bna.");
+            var htmlPage = await httpResponse.Content.ReadAsStringAsync();
+
+            return await GetDataFromHtmlAsync(htmlPage, date);
+        }
+
+        private async Task<EntityOperationResult<CurrencyDto>> GetDataFromHtmlAsync(string htmlPage, DateTime date)
+        {
+            var result = new EntityOperationResult<CurrencyDto>();
+            dynamic data = JsonConvert.DeserializeObject(htmlPage);
+
+            if (data != null)
+            {
+                result.Entity = new CurrencyDto
+                {
+                    SaleValue = data[0].valor,
+                    CurrencyName = ServiceSettings.CurrencyName,
+                    CurrencyCode = ServiceSettings.CurrencyCode.ToUpper()
+                };
+            }
+            else
+            {
+                await SendSlackNotification(htmlPage, date, CurrencyCodeEnum.Cop);
+                result.AddError("Html Error COP currency", "Error getting currency.");
+            }
+
+            return result;
+        }
+    }
+}

--- a/Doppler.Currency/Services/TrmHandler.cs
+++ b/Doppler.Currency/Services/TrmHandler.cs
@@ -35,11 +35,11 @@ namespace Doppler.Currency.Services
                 Method = new HttpMethod("GET")
             };
 
-            Logger.LogInformation("Sending request to Bna server.");
+            Logger.LogInformation("Sending request to Trm server.");
             var client = HttpClientFactory.CreateClient();
             var httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
 
-            Logger.LogInformation("Getting Html content of the Bna.");
+            Logger.LogInformation("Getting Html content of the Trm.");
             var jsonContent = await httpResponse.Content.ReadAsStringAsync();
 
             return await GetDataFromHtmlAsync(jsonContent, date);

--- a/Doppler.Currency/Services/TrmHandler.cs
+++ b/Doppler.Currency/Services/TrmHandler.cs
@@ -40,20 +40,21 @@ namespace Doppler.Currency.Services
             var httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
 
             Logger.LogInformation("Getting Html content of the Bna.");
-            var htmlPage = await httpResponse.Content.ReadAsStringAsync();
+            var jsonContent = await httpResponse.Content.ReadAsStringAsync();
 
-            return await GetDataFromHtmlAsync(htmlPage, date);
+            return await GetDataFromHtmlAsync(jsonContent, date);
         }
 
-        private async Task<EntityOperationResult<CurrencyDto>> GetDataFromHtmlAsync(string htmlPage, DateTime date)
+        private async Task<EntityOperationResult<CurrencyDto>> GetDataFromHtmlAsync(string jsonContent, DateTime date)
         {
             var result = new EntityOperationResult<CurrencyDto>();
-            dynamic data = JsonConvert.DeserializeObject(htmlPage);
+            dynamic data = JsonConvert.DeserializeObject(jsonContent);
 
             if (data != null)
             {
                 result.Entity = new CurrencyDto
                 {
+                    Date = $"{date.ToUniversalTime():yyyy-MM-dd}",
                     SaleValue = data[0].valor,
                     CurrencyName = ServiceSettings.CurrencyName,
                     CurrencyCode = ServiceSettings.CurrencyCode.ToUpper()
@@ -61,7 +62,7 @@ namespace Doppler.Currency.Services
             }
             else
             {
-                await SendSlackNotification(htmlPage, date, CurrencyCodeEnum.Cop);
+                await SendSlackNotification(jsonContent, date, CurrencyCodeEnum.Cop);
                 result.AddError("Html Error COP currency", "Error getting currency.");
             }
 

--- a/Doppler.Currency/SlackHookServiceCollectionExtensions.cs
+++ b/Doppler.Currency/SlackHookServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using CrossCutting;
 using CrossCutting.SlackHooksService;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Doppler.Currency
 {
+    [ExcludeFromCodeCoverage]
     public static class SlackHookServiceCollectionExtensions
     {
         public static IServiceCollection AddSlackHook(this IServiceCollection services)

--- a/Doppler.Currency/Startup.cs
+++ b/Doppler.Currency/Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -20,6 +21,7 @@ using Polly.Extensions.Http;
 
 namespace Doppler.Currency
 {
+    [ExcludeFromCodeCoverage]
     public class Startup
     {
         public Startup(IConfiguration configuration)

--- a/Doppler.Currency/Startup.cs
+++ b/Doppler.Currency/Startup.cs
@@ -33,6 +33,7 @@ namespace Doppler.Currency
         {
             services.Configure<CurrencySettings>("BnaService", Configuration.GetSection("CurrencyCode:BnaService"));
             services.Configure<CurrencySettings>("DofService", Configuration.GetSection("CurrencyCode:DofService"));
+            services.Configure<CurrencySettings>("TrmService", Configuration.GetSection("CurrencyCode:TrmService"));
 
             services.AddControllers()
                 .AddJsonOptions(options => { options.JsonSerializerOptions.IgnoreNullValues = true; });
@@ -68,11 +69,13 @@ namespace Doppler.Currency
 
             services.AddTransient<DofHandler>();
             services.AddTransient<BnaHandler>();
+            services.AddTransient<TrmHandler>();
             services.AddTransient<IReadOnlyDictionary<CurrencyCodeEnum, CurrencyHandler>>(sp => 
                 new Dictionary<CurrencyCodeEnum, CurrencyHandler>
                 {
                     { CurrencyCodeEnum.Ars, sp.GetRequiredService<BnaHandler>() },
-                    { CurrencyCodeEnum.Mxn, sp.GetRequiredService<DofHandler>() }
+                    { CurrencyCodeEnum.Mxn, sp.GetRequiredService<DofHandler>() },
+                    { CurrencyCodeEnum.Cop, sp.GetService<TrmHandler>() }
                 });
 
             services.AddDopplerSecurity();

--- a/Doppler.Currency/Startup.cs
+++ b/Doppler.Currency/Startup.cs
@@ -77,7 +77,7 @@ namespace Doppler.Currency
                 {
                     { CurrencyCodeEnum.Ars, sp.GetRequiredService<BnaHandler>() },
                     { CurrencyCodeEnum.Mxn, sp.GetRequiredService<DofHandler>() },
-                    { CurrencyCodeEnum.Cop, sp.GetService<TrmHandler>() }
+                    { CurrencyCodeEnum.Cop, sp.GetRequiredService<TrmHandler>() }
                 });
 
             services.AddDopplerSecurity();

--- a/Doppler.Currency/appsettings.json
+++ b/Doppler.Currency/appsettings.json
@@ -42,7 +42,14 @@
       "NoCurrency": "There are no pending USD currency for that date.",
       "CurrencyCode": "MXN",
       "CurrencyName": "Peso Mexicano"
-    }
+    },
+    "TrmService": {
+      "Url": "https://www.datos.gov.co/resource/ceyp-9c7c.json?VIGENCIAHASTA=",
+      "ValidationHtml": "",
+      "NoCurrency": "There are no pending USD currency for that date.",
+      "CurrencyCode": "COP",
+      "CurrencyName": "Peso Colombiano"
+    } 
   },
   "SlackHook": {
     "Url": "[SECRET_KEY]",


### PR DESCRIPTION
# Summary
Add support for Colombia COP currency, the endpoint is:

`/Currency/{countryCode}/{date}`

- CountryCode mandatory
- Date mandatory

See documentation: https://docs.google.com/document/d/16dEgBjKeHtqGhjMEI2DfFDjlEQJttM381nluB08kyRU/edit

# Changes
- Add Dictionary with TrmHandler to select in execution time the correct country handler
- Add Swagger annotation for more information in Swagger UI
- Add more Unit tests
- Exclude coverage of unnecessary code for testing 

# Class diagram 

![currencyHandler](https://user-images.githubusercontent.com/6796523/90683778-7c07f480-e23d-11ea-8901-f4b0ed041a91.png)


If you want to to add a new country yo can create a new Handler and add appsetting.json key as Arg and Mex
