### PR TITLE
[DAT-90] - Implement factory to Currency handlers

### DIFF
--- a/Doppler.Currency.Test/BnaHandlerTests.cs
+++ b/Doppler.Currency.Test/BnaHandlerTests.cs
@@ -83,7 +83,7 @@ namespace Doppler.Currency.Test
             _httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
                 .Returns(_httpClient);
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var bnaHandler = new BnaHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -93,7 +93,7 @@ namespace Doppler.Currency.Test
                 Mock.Of<ISlackHooksService>(),
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Ars);
+            var result = await bnaHandler.Handle(dateTime);
 
             Assert.Equal("2020-02-05", result.Entity.Date);
             Assert.Equal(58.0000M, result.Entity.BuyValue);
@@ -137,17 +137,17 @@ namespace Doppler.Currency.Test
             _httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
                 .Returns(_httpClient);
 
-            var service = CreateSutCurrencyService.CreateSut(
-                _httpClientFactoryMock.Object,
-                new HttpClientPoliciesSettings
-                {
-                    ClientName = "test"
-                },
-                _mockUsdCurrencySettings.Object,
-                Mock.Of<ISlackHooksService>(),
-                Mock.Of<ILogger<CurrencyHandler>>());
+            var bnaHandler = new BnaHandler(
+                 _httpClientFactoryMock.Object,
+                 new HttpClientPoliciesSettings
+                 {
+                     ClientName = "test"
+                 },
+                 _mockUsdCurrencySettings.Object,
+                 Mock.Of<ISlackHooksService>(),
+                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Ars);
+            var result = await bnaHandler.Handle(dateTime);
 
             Assert.Equal("2020-02-04", result.Entity.Date);
         }
@@ -171,7 +171,7 @@ namespace Doppler.Currency.Test
                     It.IsAny<string>()))
                 .Verifiable();
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var bnaHandler = new BnaHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -181,7 +181,7 @@ namespace Doppler.Currency.Test
                 slackHooksServiceMock.Object,
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            await service.GetCurrencyByCurrencyCodeAndDate(DateTime.Now, CurrencyCodeEnum.Ars);
+            await bnaHandler.Handle(DateTime.Now);
 
             slackHooksServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Once);
         }
@@ -216,7 +216,7 @@ namespace Doppler.Currency.Test
             slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<string>()))
                 .Verifiable();
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var bnaHandler = new BnaHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -226,7 +226,7 @@ namespace Doppler.Currency.Test
                 slackHooksServiceMock.Object,
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(DateTime.Now, CurrencyCodeEnum.Ars);
+            var result = await bnaHandler.Handle(DateTime.Now);
 
             slackHooksServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Never);
 
@@ -270,7 +270,7 @@ namespace Doppler.Currency.Test
                     It.IsAny<string>()))
                 .Verifiable();
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var bnaHandler = new BnaHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -280,7 +280,7 @@ namespace Doppler.Currency.Test
                 slackHooksServiceMock.Object,
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(DateTime.UtcNow.AddYears(1), CurrencyCodeEnum.Ars);
+            var result = await bnaHandler.Handle(DateTime.UtcNow.AddYears(1));
 
             slackHooksServiceMock.Verify(x => x.SendNotification(
                 It.IsAny<string>()), Times.Never);
@@ -324,7 +324,7 @@ namespace Doppler.Currency.Test
 
             var loggerMock = new Mock<ILogger<CurrencyHandler>>();
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var bnaHandler = new BnaHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -332,10 +332,9 @@ namespace Doppler.Currency.Test
                 },
                 _mockUsdCurrencySettings.Object,
                 slackHooksServiceMock.Object,
-                loggerService: Mock.Of<ILogger<CurrencyService>>(),
-                loggerHandler: loggerMock.Object);
+                loggerMock.Object);
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Ars);
+            var result = await bnaHandler.Handle(dateTime);
 
             Assert.False(result.Success);
 

--- a/Doppler.Currency.Test/DofHandlerTests.cs
+++ b/Doppler.Currency.Test/DofHandlerTests.cs
@@ -70,7 +70,8 @@ namespace Doppler.Currency.Test
 
             _httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
                 .Returns(_httpClient);
-            var service = CreateSutCurrencyService.CreateSut(
+
+            var dofHandlder = new DofHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -80,7 +81,7 @@ namespace Doppler.Currency.Test
                 Mock.Of<ISlackHooksService>(),
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Mxn);
+            var result = await dofHandlder.Handle(dateTime);
             
             Assert.Equal("2020-02-05", result.Entity.Date);
             Assert.Equal(18.679700M, result.Entity.SaleValue);
@@ -123,7 +124,7 @@ namespace Doppler.Currency.Test
             slackHooksServiceMock.Setup(x => x.SendNotification( It.IsAny<string>()))
                 .Verifiable();
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var dofHandlder = new DofHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -133,7 +134,7 @@ namespace Doppler.Currency.Test
                 slackHooksServiceMock.Object,
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(DateTime.Now, CurrencyCodeEnum.Mxn);
+            var result = await dofHandlder.Handle(DateTime.Now);
 
             Assert.False(result.Success);
             slackHooksServiceMock.Verify(x => x.SendNotification(
@@ -171,7 +172,7 @@ namespace Doppler.Currency.Test
             slackHooksServiceMock.Setup(x => x.SendNotification(It.IsAny<string>()))
                 .Verifiable();
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var dofHandlder = new DofHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -181,7 +182,7 @@ namespace Doppler.Currency.Test
                 slackHooksServiceMock.Object,
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(DateTime.Now, CurrencyCodeEnum.Mxn);
+            var result = await dofHandlder.Handle(DateTime.Now);
 
             Assert.False(result.Success);
 
@@ -231,7 +232,7 @@ namespace Doppler.Currency.Test
 
             var loggerMock = new Mock<ILogger<CurrencyHandler>>();
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var dofHandlder = new DofHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -241,7 +242,7 @@ namespace Doppler.Currency.Test
                 slackHooksServiceMock.Object,
                 loggerMock.Object);
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Mxn);
+            var result = await dofHandlder.Handle(dateTime);
 
             Assert.False(result.Success);
 

--- a/Doppler.Currency.Test/Integration/CreateSutCurrencyService.cs
+++ b/Doppler.Currency.Test/Integration/CreateSutCurrencyService.cs
@@ -1,12 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Net.Http;
-using CrossCutting.SlackHooksService;
-using Doppler.Currency.Enums;
+﻿using System.Diagnostics.CodeAnalysis;
+using Doppler.Currency.Factory;
 using Doppler.Currency.Services;
-using Doppler.Currency.Settings;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Doppler.Currency.Test.Integration
@@ -15,44 +10,12 @@ namespace Doppler.Currency.Test.Integration
     public static class CreateSutCurrencyService
     {
         public static CurrencyService CreateSut(
-            IHttpClientFactory httpClientFactory = null,
-            HttpClientPoliciesSettings httpClientPoliciesSettings = null,
-            IOptionsMonitor<CurrencySettings> currencySettings = null,
-            ISlackHooksService slackHooksService = null,
-            ILogger<CurrencyHandler> loggerHandler = null,
-            ILogger<CurrencyService> loggerService = null)
+            ILogger<CurrencyService> loggerService = null,
+            ICurrencyFactory currencyFactory = null)
         {
-            var bnaHandler = new BnaHandler(
-                httpClientFactory,
-                httpClientPoliciesSettings,
-                currencySettings,
-                slackHooksService,
-                loggerHandler ?? Mock.Of<ILogger<CurrencyHandler>>());
-
-            var dofHandler = new DofHandler(
-                httpClientFactory,
-                httpClientPoliciesSettings,
-                currencySettings,
-                slackHooksService,
-                loggerHandler ?? Mock.Of<ILogger<CurrencyHandler>>());
-
-            var trmHandler= new TrmHandler(
-                httpClientFactory,
-                httpClientPoliciesSettings,
-                currencySettings,
-                slackHooksService,
-                loggerHandler ?? Mock.Of<ILogger<CurrencyHandler>>());
-
-            var handler = new Dictionary<CurrencyCodeEnum, CurrencyHandler>
-            {
-                { CurrencyCodeEnum.Ars, bnaHandler },
-                { CurrencyCodeEnum.Mxn, dofHandler },
-                { CurrencyCodeEnum.Cop, trmHandler }
-            };
-
             return new CurrencyService(
                 loggerService ?? Mock.Of<ILogger<CurrencyService>>(),
-                handler);
+                currencyFactory ?? Mock.Of<ICurrencyFactory>());
         }
     }
 }

--- a/Doppler.Currency.Test/TrmHandlerTest.cs
+++ b/Doppler.Currency.Test/TrmHandlerTest.cs
@@ -55,7 +55,7 @@ namespace Doppler.Currency.Test
             _httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
                 .Returns(_httpClient);
 
-            var service = CreateSutCurrencyService.CreateSut(
+            var trmHandler = new TrmHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -65,7 +65,7 @@ namespace Doppler.Currency.Test
                 Mock.Of<ISlackHooksService>(),
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Cop);
+            var result = await trmHandler.Handle(dateTime);
 
             Assert.Equal("2020-02-05", result.Entity.Date);
             Assert.Equal("Peso Colombiano", result.Entity.CurrencyName);
@@ -89,7 +89,7 @@ namespace Doppler.Currency.Test
                 .Returns(_httpClient);
 
             var slackHookServiceMock = new Mock<ISlackHooksService>();
-            var service = CreateSutCurrencyService.CreateSut(
+            var trmHandler = new TrmHandler(
                 _httpClientFactoryMock.Object,
                 new HttpClientPoliciesSettings
                 {
@@ -99,7 +99,7 @@ namespace Doppler.Currency.Test
                 slackHookServiceMock.Object,
                 Mock.Of<ILogger<CurrencyHandler>>());
 
-            var result = await service.GetCurrencyByCurrencyCodeAndDate(dateTime, CurrencyCodeEnum.Cop);
+            var result = await trmHandler.Handle(dateTime);
 
            Assert.Null(result.Entity);
            Assert.Equal(1, result.Errors.Count);

--- a/Doppler.Currency/Doppler.Currency.csproj
+++ b/Doppler.Currency/Doppler.Currency.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/Doppler.Currency/Factory/CurrencyFactory.cs
+++ b/Doppler.Currency/Factory/CurrencyFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Doppler.Currency.Enums;
+using Doppler.Currency.Services;
+
+namespace Doppler.Currency.Factory
+{
+    /// <summary>
+    /// Class for the Currency factory
+    /// </summary>
+    public class CurrencyFactory : ICurrencyFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public CurrencyFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        /// <summary>
+        /// Create a handler depending of currency code.
+        /// </summary>
+        /// <param name="currencyCode">The currency code</param>
+        /// <returns>A handler</returns>
+        public CurrencyHandler CreateHandler(CurrencyCodeEnum currencyCode)
+        {
+            switch (currencyCode)
+            {
+                case CurrencyCodeEnum.Ars:
+                    return (BnaHandler)_serviceProvider.GetService(typeof(BnaHandler));
+                case CurrencyCodeEnum.Mxn:
+                    return (DofHandler)_serviceProvider.GetService(typeof(DofHandler));
+                case CurrencyCodeEnum.Cop:
+                    return (TrmHandler)_serviceProvider.GetService(typeof(TrmHandler));
+                default:
+                    throw new ArgumentException(nameof(currencyCode), $"The currencyCode '{currencyCode}' is not supported.");
+            }
+        }
+    }
+}

--- a/Doppler.Currency/Factory/ICurrencyFactory.cs
+++ b/Doppler.Currency/Factory/ICurrencyFactory.cs
@@ -1,0 +1,18 @@
+﻿using Doppler.Currency.Enums;
+using Doppler.Currency.Services;
+
+namespace Doppler.Currency.Factory
+{
+    /// <summary>
+    /// Interface for the Currency factory
+    /// </summary>
+    public interface ICurrencyFactory
+    {
+        /// <summary>
+        /// Create a handler depending of currency code.
+        /// </summary>
+        /// <param name="currencyCode">The currency code</param>
+        /// <returns>A handler</returns>
+        CurrencyHandler CreateHandler(CurrencyCodeEnum currencyCode);
+    }
+}


### PR DESCRIPTION
Currently the application injects a dictonary with all currency handler. The idea is use a factory class to remove the dictionary and create the handler uisng a factory.

![image](https://user-images.githubusercontent.com/70591946/92250406-cde98500-eea1-11ea-8ca9-d88b152f86b8.png)

**Changes:**

- Added a Factory class to create a currency handler depending the currency code. At the moment support the curruncy code: 
   Ars, Mxn and Cop. 

    ```csharp
            switch (currencyCode)
            {
                case CurrencyCodeEnum.Ars:
                    return (BnaHandler)_serviceProvider.GetService(typeof(BnaHandler));
                case CurrencyCodeEnum.Mxn:
                    return (DofHandler)_serviceProvider.GetService(typeof(DofHandler));
                case CurrencyCodeEnum.Cop:
                    return (TrmHandler)_serviceProvider.GetService(typeof(TrmHandler));
                default:
                    throw new ArgumentException(nameof(currencyCode), $"The currencyCode '{currencyCode}' is not supported.");
            }
    ```

    If the service recives another currency code it throws ArgumentException with the message: "The currencyCode 'abc' is not 
    supported."

    
    ![image](https://user-images.githubusercontent.com/70591946/92249388-60892480-eea0-11ea-9681-de34a018401d.png)


     Add the injection in the startup:
    
    
     ![Add_Factory_Injection_Factory](https://user-images.githubusercontent.com/70591946/92250683-24ef5a00-eea2-11ea-81a7-3b1bf102ba84.png)



- Ordered all injection about Currency settings, Currency handlers, Currency service and Currency factory.
   
   ![Order_Injections](https://user-images.githubusercontent.com/70591946/92249896-28361600-eea1-11ea-99b6-2ac86be8feb4.png)

- Update some Unit Tests




    