### PR TITLE
[DAT-94] Fix url for currency endpoint

### DIFF
--- a/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
+++ b/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
@@ -56,7 +56,7 @@ namespace Doppler.Currency.Test.Integration
                 });
 
             // Act
-            var response = await _client.GetAsync($"Currency/{currencyCode}/{dateTime}");
+            var response = await _client.GetAsync($"billing-currency/{currencyCode}/{dateTime}");
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();
@@ -83,7 +83,7 @@ namespace Doppler.Currency.Test.Integration
                 .ReturnsAsync(result);
 
             // Act
-            var response = await _client.GetAsync("Currency/Ars/01-02-2012");
+            var response = await _client.GetAsync("billing-currency/Ars/01-02-2012");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -132,7 +132,7 @@ namespace Doppler.Currency.Test.Integration
         public async Task GetCurrency_ShouldBeHttpStatusCodeBadRequest_WhenDateIsMajorThatDateNow()
         {
             // Act
-            var response = await _client.GetAsync("Currency/1/02-02-2550");
+            var response = await _client.GetAsync("billing-currency/1/02-02-2550");
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -155,7 +155,7 @@ namespace Doppler.Currency.Test.Integration
         public async Task GetCurrency_ShouldBeHttpStatusCodeBadRequest_WhenUrlDoesHaveInvalidDateTime(string dateTime, string currencyCode)
         {
             // Act
-            var response = await _client.GetAsync($"Currency/{currencyCode}/{dateTime}");
+            var response = await _client.GetAsync($"billing-currency/{currencyCode}/{dateTime}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -200,7 +200,7 @@ namespace Doppler.Currency.Test.Integration
             string currencyCode)
         {
             // Act
-            var response = await _client.GetAsync($"Currency/{currencyCode}/2020-2-7");
+            var response = await _client.GetAsync($"billing-currency/{currencyCode}/2020-2-7");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -216,7 +216,7 @@ namespace Doppler.Currency.Test.Integration
             var client = server.CreateClient();
 
             // Act
-            var response = await client.GetAsync("Currency/1/2020-2-7");
+            var response = await client.GetAsync("billing-currency/1/2020-2-7");
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -230,7 +230,7 @@ namespace Doppler.Currency.Test.Integration
                 .UseStartup<Startup>();
             var server = new TestServer(builder);
             var client = server.CreateClient();
-            var request = new HttpRequestMessage(HttpMethod.Get, "https://custom.domain.com/currency/1/2020-2-7");
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://custom.domain.com/billing-currency/1/2020-2-7");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjg4NDY5LCJ1bmlxdWVfbmFtZSI6ImFtb3NjaGluaUBtYWtpbmdzZW5zZS5jb20iLCJpc1N1IjpmYWxzZSwic3ViIjoiYW1vc2NoaW5pQG1ha2luZ3NlbnNlLmNvbSIsImN1c3RvbWVySWQiOiIxMzY3IiwiY2RoX2N1c3RvbWVySWQiOiIxMzY3Iiwicm9sZSI6IlVTRVIiLCJpYXQiOjE1OTQxNTUwMjYsImV4cCI6MTU5NDE1NjgyNn0.a4eVqSBptPJk0y9V5Id1yXEzkSroX7j9712W6HOYzb-9irc3pVFQrdWboHcZPLlbpHUdsuoHmFOU-l14N_CjVF9mwjz0Qp9x88JP2KD1x8YtlxUl4BkIneX6ODQ5q_hDeQX-yIUGoU2-cIXzle-JzRssg-XIbaf34fXnUSiUGnQRAuWg3IkmpeLu9fVSbYrY-qW1os1gBSq4NEESz4T87hJblJv3HWNQFJxAtvhG4MLX2ITm8vYNtX39pwI5gdkLY7bNzWmJ1Uphz1hR-sdCdM2oUWKmRmL7txsoD04w5ca7YbdHQGwCI92We4muOs0-N7a4JHYjuDM9lL_TbJGw2w");
 
             // Act

--- a/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
+++ b/Doppler.Currency.Test/Integration/CurrencyControllerTests.cs
@@ -56,7 +56,7 @@ namespace Doppler.Currency.Test.Integration
                 });
 
             // Act
-            var response = await _client.GetAsync($"billing-currency/{currencyCode}/{dateTime}");
+            var response = await _client.GetAsync($"conversion/{currencyCode}/{dateTime}");
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();
@@ -83,7 +83,7 @@ namespace Doppler.Currency.Test.Integration
                 .ReturnsAsync(result);
 
             // Act
-            var response = await _client.GetAsync("billing-currency/Ars/01-02-2012");
+            var response = await _client.GetAsync("conversion/Ars/01-02-2012");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -93,7 +93,7 @@ namespace Doppler.Currency.Test.Integration
         public async Task GetCurrency_ShouldBeHttpStatusCodeNotFound_WhenUrlDoesNotHaveDateTime()
         {
             // Act
-            var response = await _client.GetAsync("Currency/Ars");
+            var response = await _client.GetAsync("conversion/Ars");
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -103,7 +103,7 @@ namespace Doppler.Currency.Test.Integration
         public async Task GetCurrency_ShouldBeHttpStatusCodeNotFound_WhenUrlDoesNotHaveCurrencyCode()
         {
             // Act
-            var response = await _client.GetAsync("Currency/02-02-2020");
+            var response = await _client.GetAsync("conversion/02-02-2020");
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -122,7 +122,7 @@ namespace Doppler.Currency.Test.Integration
                 .ReturnsAsync(result);
 
             // Act
-            var response = await _client.GetAsync("Currency/TEST/02-02-2020");
+            var response = await _client.GetAsync("conversion/TEST/02-02-2020");
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -132,7 +132,7 @@ namespace Doppler.Currency.Test.Integration
         public async Task GetCurrency_ShouldBeHttpStatusCodeBadRequest_WhenDateIsMajorThatDateNow()
         {
             // Act
-            var response = await _client.GetAsync("billing-currency/1/02-02-2550");
+            var response = await _client.GetAsync("conversion/1/02-02-2550");
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -155,7 +155,7 @@ namespace Doppler.Currency.Test.Integration
         public async Task GetCurrency_ShouldBeHttpStatusCodeBadRequest_WhenUrlDoesHaveInvalidDateTime(string dateTime, string currencyCode)
         {
             // Act
-            var response = await _client.GetAsync($"billing-currency/{currencyCode}/{dateTime}");
+            var response = await _client.GetAsync($"conversion/{currencyCode}/{dateTime}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -171,7 +171,7 @@ namespace Doppler.Currency.Test.Integration
         public async Task GetCurrency_ShouldBeHttpStatusCodeNotFound_WhenUrlDoesHaveNullAndEmptyDateTime(string dateTime, string currencyCode)
         {
             // Act
-            var response = await _client.GetAsync($"Currency/{currencyCode}/{dateTime}");
+            var response = await _client.GetAsync($"conversion/{currencyCode}/{dateTime}");
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -185,7 +185,7 @@ namespace Doppler.Currency.Test.Integration
         public async Task GetCurrency_ShouldBeHttpStatusCodeNotFound_WhenUrlDoesHaveInDateTimeInvalidCharacter(string dateTime)
         {
             // Act
-            var response = await _client.GetAsync($"Currency/Arg/{dateTime}");
+            var response = await _client.GetAsync($"conversion/Arg/{dateTime}");
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -200,7 +200,7 @@ namespace Doppler.Currency.Test.Integration
             string currencyCode)
         {
             // Act
-            var response = await _client.GetAsync($"billing-currency/{currencyCode}/2020-2-7");
+            var response = await _client.GetAsync($"conversion/{currencyCode}/2020-2-7");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -216,7 +216,7 @@ namespace Doppler.Currency.Test.Integration
             var client = server.CreateClient();
 
             // Act
-            var response = await client.GetAsync("billing-currency/1/2020-2-7");
+            var response = await client.GetAsync("conversion/1/2020-2-7");
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -230,7 +230,7 @@ namespace Doppler.Currency.Test.Integration
                 .UseStartup<Startup>();
             var server = new TestServer(builder);
             var client = server.CreateClient();
-            var request = new HttpRequestMessage(HttpMethod.Get, "https://custom.domain.com/billing-currency/1/2020-2-7");
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://custom.domain.com/conversion/1/2020-2-7");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjg4NDY5LCJ1bmlxdWVfbmFtZSI6ImFtb3NjaGluaUBtYWtpbmdzZW5zZS5jb20iLCJpc1N1IjpmYWxzZSwic3ViIjoiYW1vc2NoaW5pQG1ha2luZ3NlbnNlLmNvbSIsImN1c3RvbWVySWQiOiIxMzY3IiwiY2RoX2N1c3RvbWVySWQiOiIxMzY3Iiwicm9sZSI6IlVTRVIiLCJpYXQiOjE1OTQxNTUwMjYsImV4cCI6MTU5NDE1NjgyNn0.a4eVqSBptPJk0y9V5Id1yXEzkSroX7j9712W6HOYzb-9irc3pVFQrdWboHcZPLlbpHUdsuoHmFOU-l14N_CjVF9mwjz0Qp9x88JP2KD1x8YtlxUl4BkIneX6ODQ5q_hDeQX-yIUGoU2-cIXzle-JzRssg-XIbaf34fXnUSiUGnQRAuWg3IkmpeLu9fVSbYrY-qW1os1gBSq4NEESz4T87hJblJv3HWNQFJxAtvhG4MLX2ITm8vYNtX39pwI5gdkLY7bNzWmJ1Uphz1hR-sdCdM2oUWKmRmL7txsoD04w5ca7YbdHQGwCI92We4muOs0-N7a4JHYjuDM9lL_TbJGw2w");
 
             // Act

--- a/Doppler.Currency/Controllers/CurrencyController.cs
+++ b/Doppler.Currency/Controllers/CurrencyController.cs
@@ -11,7 +11,6 @@ using Swashbuckle.AspNetCore.Annotations;
 namespace Doppler.Currency.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
     [Authorize]
     public class CurrencyController : ControllerBase
     {
@@ -21,7 +20,7 @@ namespace Doppler.Currency.Controllers
         public CurrencyController(ILogger<CurrencyController> logger, ICurrencyService currencyService) => 
             (_logger, _currencyService) = (logger, currencyService);
 
-        [HttpGet("{currencyCode}/{date}")]
+        [HttpGet("billing-currency/{currencyCode}/{date}")]
         [SwaggerOperation(Summary = "Get currency by currency code and date")]
         [SwaggerResponse(200, "The currency is ok", typeof(CurrencyDto))]
         [SwaggerResponse(400, "The currency data is invalid")]

--- a/Doppler.Currency/Controllers/CurrencyController.cs
+++ b/Doppler.Currency/Controllers/CurrencyController.cs
@@ -20,7 +20,7 @@ namespace Doppler.Currency.Controllers
         public CurrencyController(ILogger<CurrencyController> logger, ICurrencyService currencyService) => 
             (_logger, _currencyService) = (logger, currencyService);
 
-        [HttpGet("billing-currency/{currencyCode}/{date}")]
+        [HttpGet("conversion/{currencyCode}/{date}")]
         [SwaggerOperation(Summary = "Get currency by currency code and date")]
         [SwaggerResponse(200, "The currency is ok", typeof(CurrencyDto))]
         [SwaggerResponse(400, "The currency data is invalid")]

--- a/Doppler.Currency/Startup.cs
+++ b/Doppler.Currency/Startup.cs
@@ -64,11 +64,6 @@ namespace Doppler.Currency
                     Description = "API for Doppler Currency"
                 });
 
-                var security = new Dictionary<string, IEnumerable<string>>
-                {
-                    { "Bearer", Array.Empty<string>() },
-                };
-
                 c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
                 {
                     Description = "JWT Authorization header using the Bearer scheme (Example: 'Bearer 12345abcdef')",
@@ -153,12 +148,16 @@ namespace Doppler.Currency
                 endpoints.MapControllers();
             });
 
-            app.UseSwagger();
 
-            app.UseSwaggerUI(c =>
+            if (env.IsDevelopment())
             {
-                c.SwaggerEndpoint("v1/swagger.json", "Doppler Currency API V1");
-            });
+                app.UseSwagger();
+
+                app.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("v1/swagger.json", "Doppler Currency API V1");
+                });
+            }
         }
     }
 }

--- a/Doppler.Currency/Startup.cs
+++ b/Doppler.Currency/Startup.cs
@@ -148,7 +148,7 @@ namespace Doppler.Currency
                 endpoints.MapControllers();
             });
 
-
+            // Swagger is disabled for int QA and prod because need set up for a reverse proxy
             if (env.IsDevelopment())
             {
                 app.UseSwagger();


### PR DESCRIPTION
# Background
Add a new URL for Doppler.currency, add prefix `conversion`

Local: http://localhost:5001/billing-currency/1/2020-09-08
Int: https://apisint.fromdoppler.net/currency/conversion/{CurrencyCode}/{date}
Qa: https://apisqa.fromdoppler.net/currency/conversion/{CurrencyCode}/{date}
Prod: https://apis.fromdoppler.com/currency/conversion/{CurrencyCode}/{date}

Swagger only in local: http://localhost:5001/swagger/index.html