### PR TITLE
DAT-106-Holiday-Mexico

### DIFF
--- a/Doppler.Currency/Services/DofHandler.cs
+++ b/Doppler.Currency/Services/DofHandler.cs
@@ -84,8 +84,9 @@ namespace Doppler.Currency.Services
                 return result;
             }
 
-            await SendSlackNotification(htmlPage, date, CurrencyCodeEnum.Mxn);
-            result.AddError("Html Error Mxn currency", "Error getting HTML or date is holiday, please check HTML.");
+            //No price for current date
+            Logger.LogInformation("Creating Currency object with No Price.");
+            result.Entity = CreateCurrency(date, "0", ServiceSettings.CurrencyCode);
             return result;
         }
     }


### PR DESCRIPTION
Updated of the logic when the current date hasn't price (holiday) for the Mexico.

Task: [DAT-106](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-106)

**Changes:**

Now, when the current day hasn't price returns a CurrencyDto object with the "CotizationAvailable" property equal false and Status = Ok instead of Bad Request

Example:

![image](https://user-images.githubusercontent.com/70591946/93220251-9f419900-f742-11ea-9e2e-62e0ddbdaed9.png)

Also updated the UTs.