### PR TITLE
DAT-107-Holiday-Colombia

### DIFF
--- a/Doppler.Currency.Test/TrmHandlerTest.cs
+++ b/Doppler.Currency.Test/TrmHandlerTest.cs
@@ -67,13 +67,15 @@ namespace Doppler.Currency.Test
 
             var result = await trmHandler.Handle(dateTime);
 
+            Assert.True(result.Success);
+            Assert.True(result.Entity.CotizationAvailable);
             Assert.Equal("2020-02-05", result.Entity.Date);
             Assert.Equal("Peso Colombiano", result.Entity.CurrencyName);
             Assert.Equal("COP", result.Entity.CurrencyCode);
         }
 
         [Fact]
-        public async Task GetCurrency_ShouldBeSendSlackNotification_WhenTrmDoesNotHaveInformation()
+        public async Task GetCurrency_ShouldBeReturnCotizationAvailableFalseAndOk_WhenTrmDoesNotHaveInformation()
         {
             var dateTime = new DateTime(2020, 02, 05);
 
@@ -82,7 +84,7 @@ namespace Doppler.Currency.Test
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent("")
+                    Content = new StringContent("[]")
                 });
 
             _httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
@@ -101,9 +103,8 @@ namespace Doppler.Currency.Test
 
             var result = await trmHandler.Handle(dateTime);
 
-           Assert.Null(result.Entity);
-           Assert.Equal(1, result.Errors.Count);
-           slackHookServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Once);
+            Assert.True(result.Success);
+            Assert.False(result.Entity.CotizationAvailable);
         }
     }
 }

--- a/Doppler.Currency/Dtos/TrmResponse.cs
+++ b/Doppler.Currency/Dtos/TrmResponse.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Doppler.Currency.Dtos
+{
+    public class TrmResponse
+    {
+        public decimal Valor { get; set; }
+
+        public DateTime VigenciaDesde { get; set; }
+
+        public DateTime VigenciaHasta { get; set; }
+    }
+}


### PR DESCRIPTION
Updated of the logic when the current date hasn't price (holiday) for the Colombia.

Task: [DAT-107](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-107)

**Changes:**

- Added new entity to map the response of the TRM api.

- Changed the logic when the current day is holiday. Now, when the current day hasn't price returns a CurrencyDto object with the "CotizationAvailable" property equal false and Status = Ok instead of Bad Request

Example:

![image](https://user-images.githubusercontent.com/70591946/93244051-7da2da80-f75f-11ea-9681-1d80c5d1bf97.png)

- Updated UTs
